### PR TITLE
beatblocs and synth side by side

### DIFF
--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -1,9 +1,7 @@
 import { ChakraProvider } from '@chakra-ui/react'
 import Sequencer from './Sequencer'
 import Synth from './Synth'
-
 import BeatPixel from './BeatPixel'
-
 import { Fonts } from './Fonts'
 
 function App() {
@@ -15,11 +13,13 @@ function App() {
           <div className="sequencer">
             <Sequencer />
           </div>
-          <div className="oscillator-container">
-            <Synth />
-          </div>
-          <div className="beat-pixel">
-            <BeatPixel />
+          <div className="synth-and-pixel">
+            <div className="oscillator-container">
+              <Synth />
+            </div>
+            <div className="beat-pixel">
+              <BeatPixel />
+            </div>
           </div>
         </div>
       </div>

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -515,4 +515,18 @@ $brick-colors: (
   opacity: 0.3
 }
 
+////// styling to help make beatblocks and syth render die by side
+ 
+.app-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.synth-and-pixel {
+  display: flex;
+  flex-direction: row; /* Change to 'row' for horizontal alignment */
+  gap: 20px; /* Adjust the gap as needed */
+}
+/// 
 


### PR DESCRIPTION
A few small changes to make beatblocks and the synth sit side by side on the main app page - needs a few little formatting tweaks
